### PR TITLE
remove notation about improve-readwrite branch of vimproc, because it wa...

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is under development!
 
 * [leiningen](http://leiningen.org/)
 * [vimproc.vim](https://github.com/Shougo/vimproc.vim)
-  * Recommended [ichizok's fork improve-readwrite branch](https://github.com/ichizok/vimproc.vim/tree/improve-readwrite) + [additional patch](https://gist.github.com/ujihisa/4666b417034040295828) for speed.
+  * Recommended [additional patch](https://gist.github.com/ujihisa/4666b417034040295828) for speed.
 
 Optional dependency plugins
 


### PR DESCRIPTION
...s merged
